### PR TITLE
docs: fix names for snyk report files

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The package argument is optional. If no package is given, Snyk will run the comm
 
 Snyk is also provided as a set of Docker images that carry the runtime environment of each package manager. For example, the npm image will carry all of the needed setup to run `npm install` on the currently running container. Currently there are images for npm, Ruby, Maven, Gradle and SBT.
 
-The images can perform `snyk test` by default on the specified project which is mounted to the container as a read/write volume, and `snyk monitor` if the `MONITOR` environment variable is set when running the docker container. When running `snyk monitor` with the `GENERATE_REPORT` environment variable set, an HTML file called `snyk-report.html` and a CSS file called `snyk-report.css` will be generated. The image also writes a file called `snyk-res.json` for internal use and `snyk-error.log` for errors that we can look at if something goes wrong.
+The images can perform `snyk test` by default on the specified project which is mounted to the container as a read/write volume, and `snyk monitor` if the `MONITOR` environment variable is set when running the docker container. When running `snyk monitor` with the `GENERATE_REPORT` environment variable set, an HTML file called `snyk_report.html` and a CSS file called `snyk_report.css` will be generated. The image also writes a file called `snyk-res.json` for internal use and `snyk-error.log` for errors that we can look at if something goes wrong.
 
 
 The following environment variables can be used when running the container on docker:


### PR DESCRIPTION
- [ ] Ready for review
- [ ] Follows [CONTRIBUTING](https://github.com/snyk/snyk/blob/master/.github/CONTRIBUTING.md) rules
- [ ] Reviewed by Snyk internal team

#### What does this PR do?
Fix filenames for `snyk_report.html` and `snyk_report.css` in README.md Docker section.

Looks like a typo. Instead of dash symbol should be underscore: `snyk-report.html` => `snyk_report.html`, `snyk-report.css` => `snyk_report.css`. It can be checked in docker-entrypoint.sh file:
- https://github.com/snyk/snyk/blob/master/docker/docker-entrypoint.sh#L8
- https://github.com/snyk/snyk/blob/master/docker/docker-entrypoint.sh#L105
